### PR TITLE
チャットページでのチャット送信機能を作成した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,5 @@ gem 'devise'
 
 gem 'carrierwave', '~> 2.0'
 gem "mini_magick"
+
+gem "byebug"

--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,4 @@ gem 'devise'
 gem 'carrierwave', '~> 2.0'
 gem "mini_magick"
 
-gem "byebug"
+gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     devise (4.7.3)
@@ -124,6 +125,12 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
@@ -238,6 +245,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   mini_magick
+  pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.1)

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -20,7 +20,13 @@ class ChatRoomsController < ApplicationController
   def show
     @chat_room = ChatRoom.find(params[:id])
     @chat_room_user = @chat_room.chat_room_users.where.not(user_id: current_user.id).first.user
-    @chat_messages = ChatMessage.where(chat_room_id: @chat_room.id)
+    @chat_messages = ChatMessage.where(chat_room_id: @chat_room.id).order(:id).last(100)
+  end
+
+  def show_additionally
+    last_id = params[:oldest_message_id].to_i - 1
+    
+    @messages = ChatMessage.include(:user_id).order(:id).where(id: 1..last_id).last(50)
   end
 
 end

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -24,10 +24,10 @@ class ChatRoomsController < ApplicationController
   end
 
   def show_additionally
-    binding.pry
     last_id = params[:oldest_message_id].to_i - 1
-
-    @messages = ChatMessage.include(:user_id).order(:id).where(id: 1..last_id).last(50)
+    @chat_messages = ChatMessage.includes(:user).order(:id).where(id: 1..last_id).last(50)
+    @chat_room = ChatRoom.find(params[:id])
+    @chat_room_user = @chat_room.chat_room_users.where.not(user_id: current_user.id).first.user
   end
 
 end

--- a/app/controllers/chat_rooms_controller.rb
+++ b/app/controllers/chat_rooms_controller.rb
@@ -24,8 +24,9 @@ class ChatRoomsController < ApplicationController
   end
 
   def show_additionally
+    binding.pry
     last_id = params[:oldest_message_id].to_i - 1
-    
+
     @messages = ChatMessage.include(:user_id).order(:id).where(id: 1..last_id).last(50)
   end
 

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -48,10 +48,11 @@ document.addEventListener('turbolinks:load',() => {
       showAdditionally = false
 
       oldestMessageId = document.querySelector(".chat-message").id
+      let chat_room_id = document.querySelector(".chat-room-show-page").id
 
       $.ajax({
         type: "GET",
-        url: "/chat_rooms/show_additionally",
+        url: `/chat_rooms/${chat_room_id}/show_additionally`,
         datatype: "json",
         cache: false,
         // data-remote: trueを入れるとshow_additionally.js.erbを作動できる

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -39,6 +39,31 @@ document.addEventListener('turbolinks:load',() => {
   scrollToBottom();
 
 
+  // ここら辺が表示されてない古いメッセージを取得するコード
+  let oldestMessageId;
+  window.showAdditionally = true;
+
+  window.messageContainer.addEventListener("scroll",() => {
+    if (document.getElementById("chat-messages").scrollTop === 0 && showAdditionally){
+      showAdditionally = false
+
+      oldestMessageId = document.querySelector(".chat-message").id
+
+      $.ajax({
+        type: "GET",
+        url: "/chat_rooms/show_additionally",
+        datatype: "json",
+        cache: false,
+        // data-remote: trueを入れるとshow_additionally.js.erbを作動できる
+        data: {oldest_message_id: oldestMessageId, remote: true}
+      })
+    }
+    // passive: trueはイベントハンドラ処理が終了するまでスクロールを開始することができないという状態を回避するために書く
+  }, {passive: true});
+
+
+
+
 
   if(/chat_rooms/.test(location.pathname)){
     $(document).on("keydown", ".chat-room__message-form_textarea", function(e){
@@ -47,7 +72,6 @@ document.addEventListener('turbolinks:load',() => {
         if(!e.target.value.trim()){
           return
         }
-  
         const chat_room_id =$("textarea").data("chat_room_id");
         appChatRoom.speak(e.target.value, chat_room_id);
         e.target.value = '';

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -1,33 +1,60 @@
 import consumer from "./consumer"
 
-const appChatRoom = consumer.subscriptions.create("ChatRoomChannel", {
-  connected() {
-    // Called when the subscription is ready for use on the server
-  },
 
-  disconnected() {
-    // Called when the subscription has been terminated by the server
-  },
+document.addEventListener('turbolinks:load',() => {
 
-  received(data) {
-    const chatMessages = document.getElementById("chat-messages");
-    chatMessages.insertAdjacentHTML("beforeend", data["chat_message"])
-    // Called when there's incoming data on the websocket for this channel
-  },
-
-  speak: function(chat_message,chat_room_id) {
-    return this.perform('speak',{ chat_message: chat_message, chat_room_id: chat_room_id});
+  window.messageContainer = document.getElementById("chat-messages");
+  
+  if(messageContainer === null){
+    return
   }
-});
 
-if(/chat_rooms/.test(location.pathname)){
-  $(document).on("keydown", ".chat-room__message-form_textarea", function(e){
-    if (e.key === "Enter"){
 
-      const chat_room_id =$("textarea").data("chat_room_id");
-      appChatRoom.speak(e.target.value, chat_room_id);
-      e.target.value = '';
-      e.preventDefault();
+  const appChatRoom = consumer.subscriptions.create("ChatRoomChannel", {
+    connected() {
+      // Called when the subscription is ready for use on the server
+    },
+  
+    disconnected() {
+      // Called when the subscription has been terminated by the server
+    },
+  
+    received(data) {
+      const chatMessages = document.getElementById("chat-messages");
+      chatMessages.insertAdjacentHTML("beforeend", data["chat_message"])
+      // Called when there's incoming data on the websocket for this channel
+    },
+  
+    speak: function(chat_message,chat_room_id) {
+      return this.perform('speak',{ chat_message: chat_message, chat_room_id: chat_room_id});
     }
-  })
-}
+  });
+
+
+  let scrollHeight = document.getElementById("chat-messages").scrollHeight;
+  let scrollToBottom = () => {
+    document.getElementById("chat-messages").scrollTop = scrollHeight;
+  }
+  scrollToBottom();
+
+
+
+  if(/chat_rooms/.test(location.pathname)){
+    $(document).on("keydown", ".chat-room__message-form_textarea", function(e){
+      if (e.key === "Enter"){
+  
+        const chat_room_id =$("textarea").data("chat_room_id");
+        appChatRoom.speak(e.target.value, chat_room_id);
+        e.target.value = '';
+        e.preventDefault();
+      }
+    })
+  }
+
+
+
+})
+
+
+
+

--- a/app/javascript/channels/chat_room_channel.js
+++ b/app/javascript/channels/chat_room_channel.js
@@ -22,6 +22,7 @@ document.addEventListener('turbolinks:load',() => {
     received(data) {
       const chatMessages = document.getElementById("chat-messages");
       chatMessages.insertAdjacentHTML("beforeend", data["chat_message"])
+      scrollToBottom();
       // Called when there's incoming data on the websocket for this channel
     },
   
@@ -42,6 +43,10 @@ document.addEventListener('turbolinks:load',() => {
   if(/chat_rooms/.test(location.pathname)){
     $(document).on("keydown", ".chat-room__message-form_textarea", function(e){
       if (e.key === "Enter"){
+
+        if(!e.target.value.trim()){
+          return
+        }
   
         const chat_room_id =$("textarea").data("chat_room_id");
         appChatRoom.speak(e.target.value, chat_room_id);

--- a/app/javascript/src/swipe.js
+++ b/app/javascript/src/swipe.js
@@ -139,7 +139,6 @@ if(location.pathname == "/users"){
       let removedCards = document.querySelectorAll(".removed");
       back_card = removedCards[removedCards.length -1];
       if (!back_card) return
-      console.log(back_card);
       back_card.style.transform = "";
       back_card.classList.toggle("removed",!back_card);
       initCards();

--- a/app/javascript/stylesheets/chat_rooms/show.scss
+++ b/app/javascript/stylesheets/chat_rooms/show.scss
@@ -85,6 +85,7 @@
     font-size: 16px;
     border-radius: 8px;
     background: #f1f1f1;
+    // overflow-wrap: normal;
   }
   &__current-user {
     display: flex;

--- a/app/javascript/stylesheets/chat_rooms/show.scss
+++ b/app/javascript/stylesheets/chat_rooms/show.scss
@@ -1,9 +1,13 @@
+.chat-room__header {
+  height: 10vh;
+}
+
 .chat-room-show-page {
   max-width: 414px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  // min-height: 100vh;
   .chat-room {
     &__header {
       border-bottom: 1px solid #fafafa;
@@ -32,17 +36,25 @@
       }
     }
     &__message-form {
-      margin-top: auto;
+      height: 20vh;
       border-top: 1px solid #e8e8e8;
-      padding: 24px 24px 0 24px;
+      padding: 24px;
       width: 100%;
       &_textarea {
         width: 100%;
+        height: 100%;
         border: none;
         white-space: normal;
       }
     }
   }
+}
+
+#chat-messages {
+  min-width: 100%;
+  max-height: 70vh;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .chat-message {

--- a/app/javascript/stylesheets/users/index.scss
+++ b/app/javascript/stylesheets/users/index.scss
@@ -11,6 +11,7 @@
       width: 340px;
       height: 520px;
       object-fit: cover;
+      border-radius: 10px;
       background-image: url("~profile_default_img.png");
       background-size: contain;
       margin: auto;

--- a/app/views/chat_messages/_chat_message.html.erb
+++ b/app/views/chat_messages/_chat_message.html.erb
@@ -14,6 +14,7 @@
   <% else %>
     <div class="chat-message__current-user">
       <div class="chat-message__content main-color-bg">
+        <%= chat_message.id %>
         <%= chat_message.content %>
       </div>
     </div>

--- a/app/views/chat_messages/_chat_message.html.erb
+++ b/app/views/chat_messages/_chat_message.html.erb
@@ -1,7 +1,7 @@
 <div class="chat-message" id="<%= chat_message.id %>">
   <% if chat_message.user.id != current_user.id %>
     <div class="chat-message__partner">
-      <% if @chat_room_user.profile_image.url.nil? %>
+      <% if chat_room_user.profile_image.url.nil? %>
         <div class="chat-message__partner-default-img"></div>
       <% else %>
         <%= image_tag chat_message.user.profile_image.url, class: "chat-message__partner-img" %>

--- a/app/views/chat_messages/_chat_message.html.erb
+++ b/app/views/chat_messages/_chat_message.html.erb
@@ -1,4 +1,4 @@
-<div class="chat-message">
+<div class="chat-message" id="<%= chat_message.id %>">
   <% if chat_message.user.id != current_user.id %>
     <div class="chat-message__partner">
       <% if @chat_room_user.profile_image.url.nil? %>

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -1,4 +1,4 @@
-<div class="chat-room-show-page">
+<div class="chat-room-show-page" id="<%= @chat_room.id%>">
   <nav class="navbar navbar-light chat-room__header">
     <%= link_to matching_index_path, class: "nav-item nav-link" do%>
       <i class="fas fa-chevron-left"></i>
@@ -18,7 +18,7 @@
   </nav>
 
   <div id='chat-messages'>
-    <%= render @chat_messages %>
+    <%= render partial: 'chat_messages/chat_message', collection: @chat_messages,locals: { chat_room_user: @chat_room_user} %>
   </div>
 
   <form class="chat-room__message-form">

--- a/app/views/chat_rooms/show.html.erb
+++ b/app/views/chat_rooms/show.html.erb
@@ -22,6 +22,6 @@
   </div>
 
   <form class="chat-room__message-form">
-    <textarea data-behavior="chat_room_speaker" data-chat_room_id="<%= @chat_room.id %>" placeholder="メッセージを入力" class="chat-room__message-form_textarea"></textarea>
+    <textarea data-behavior="chat_room_speaker" data-chat_room_id="<%= @chat_room.id %>" placeholder="メッセージを入力" class="chat-room__message-form_textarea" id="chat-room-textarea"></textarea>
   </form>
 </div>

--- a/app/views/chat_rooms/show_additionally.js.erb
+++ b/app/views/chat_rooms/show_additionally.js.erb
@@ -1,5 +1,5 @@
-messageContainer.insertAdjcentHTML('afterbegin',"<%= j(render @messages) %>")
+messageContainer.insertAdjacentHTML('afterbegin',"<%= j(render partial: 'chat_messages/chat_message', collection: @chat_messages,locals: { chat_room_user: @chat_room_user}) %>")
 
-<% if @messages.peresent? %>
+<% if @chat_messages.present? %>
   showAdditionally = true
 <% end %>

--- a/app/views/chat_rooms/show_additionally.js.erb
+++ b/app/views/chat_rooms/show_additionally.js.erb
@@ -1,4 +1,12 @@
+
+var messageHeight = messageContainer.scrollHeight;
+
 messageContainer.insertAdjacentHTML('afterbegin',"<%= j(render partial: 'chat_messages/chat_message', collection: @chat_messages,locals: { chat_room_user: @chat_room_user}) %>")
+
+
+var newMessageHeight = messageContainer.scrollHeight;
+messageContainer.scrollBy(0, newMessageHeight - messageHeight);
+
 
 <% if @chat_messages.present? %>
   showAdditionally = true

--- a/app/views/chat_rooms/show_additionally.js.erb
+++ b/app/views/chat_rooms/show_additionally.js.erb
@@ -1,0 +1,5 @@
+messageContainer.insertAdjcentHTML('afterbegin',"<%= j(render @messages) %>")
+
+<% if @messages.peresent? %>
+  showAdditionally = true
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :matching , only: [:index]
 
   resources :chat_rooms, only: [:create,:show] do
-    collection do
+    member do
       get "show_additionally"
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,10 @@ Rails.application.routes.draw do
 
   resources :matching , only: [:index]
 
-  resources :chat_rooms, only: [:create,:show]
+  resources :chat_rooms, only: [:create,:show] do
+    collection do
+      get "show_additionally"
+    end
+  end
+
 end


### PR DESCRIPTION
チャットルーム遷移時に最新のチャット内容を表示すること、(はじめに100件取得)
過去のチャット内容をスクロールして辿れるようにしたこと、
スクロールして辿った際に新しく得られたチャット内容のところに画面をスクロールさせたことなど追加しました。
まだ、テキストエリアについては不完全。